### PR TITLE
Games Focus and Carousels

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "butlerd": "^14.1.0",
     "follow-redirects": "^1.14.4",
     "googledrive": "^3.2.0",
+    "jquery": "^3.6.0",
     "react": "^17.0.2",
     "react-coverflow": "^0.2.20",
     "react-dom": "^17.0.2",

--- a/src/components/GameStage/GameCard/GameCard.js
+++ b/src/components/GameStage/GameCard/GameCard.js
@@ -14,12 +14,6 @@ export default function GameCard(props) {
     : 'game-card-image';
 
   return (
-    <div id={props.game.gameInfo.name} className={classes}>
-      <GamePreview preview={props.game.gameplayPreviews[0]} />
-      {/* <img
-        variant="top"
-        src={props.game.gameInfo.imageUrl}
-      /> */}
-    </div>
+    <GamePreview preview={props.game.gameplayPreviews[0]} refCallback = {props.refCallback} className={classes}/>
   );
 }

--- a/src/components/GameStage/GameCard/GameCard.js
+++ b/src/components/GameStage/GameCard/GameCard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import GamePreview from '../GameDetail/GamePreview/GamePreview';
 import { Card } from 'react-bootstrap';
 import styles from './GameCard.css';
 
@@ -9,16 +10,16 @@ export default function GameCard(props) {
   }
 
   const classes = props.isSelected
-    ? 'game-card-image game-card-selected'
+    ? 'game-card-image game-card-selected align-center'
     : 'game-card-image';
 
   return (
-    <div id={props.game.gameInfo.name}>
-      <img
-        className={classes}
+    <div id={props.game.gameInfo.name} className={classes}>
+      <GamePreview preview={props.game.gameplayPreviews[0]} />
+      {/* <img
         variant="top"
         src={props.game.gameInfo.imageUrl}
-      />
+      /> */}
     </div>
   );
 }

--- a/src/components/GameStage/GameCarousel/GameCarousel.js
+++ b/src/components/GameStage/GameCarousel/GameCarousel.js
@@ -4,12 +4,14 @@ import GameCard from '../GameCard/GameCard';
 import { LibraryEntry } from '../../../models/libraryEntry';
 
 const GameCarousel = (props) => {
+  let slider = null;
+  let carouselElements = [];
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   useEffect(() => {
     props.setSelectedGame(props.games[selectedIndex]);
 
-    scrollSelectedCardIntoView();
+    $(slider).animate({scrollLeft: carouselElements[selectedIndex].offsetLeft - $( window ).width() + carouselElements[selectedIndex].scrollWidth}, "fast");
   }, [selectedIndex]);
 
   useEffect(() => {
@@ -17,22 +19,6 @@ const GameCarousel = (props) => {
       slider.focus();
     }
   });
-
-  function scrollSelectedCardIntoView(index) {
-    const selectedCard = document.getElementById(
-      props.games[selectedIndex].gameInfo.name
-    );
-
-    selectedCard.scrollIntoView({
-      behavior: 'smooth',
-      block: 'center',
-      inline: 'center',
-    });
-
-    console.log(props.games[selectedIndex].gameInfo);
-  }
-
-  let slider = null;
 
   let handleArrows = (event) => {
     // left arrow
@@ -48,7 +34,7 @@ const GameCarousel = (props) => {
   };
 
   let gameCards = props.games.map((game, i) => {
-    return <GameCard isSelected={i === selectedIndex} game={game} key={i} />;
+    return <GameCard isSelected={i === selectedIndex} game={game} refCallback={(div) => carouselElements.push(div)} key={i} />;
   });
 
   return (

--- a/src/components/GameStage/GameDetail/GameDetails.js
+++ b/src/components/GameStage/GameDetail/GameDetails.js
@@ -8,55 +8,14 @@ import GamePreview from './GamePreview/GamePreview';
 
 const GameDetails = (props) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [focusElement, setFocusElement] = useState('description');
 
   const [progress, setProgress] = useState(0.0);
   const [downloading, setDownloading] = useState(false);
-
-  var focusables = [];
-  const focusStrings = ['description', 'previews', 'authorInfo'];
-
-  useEffect(() => {
-    if (props.shouldFocus) {
-      focusables[selectedIndex].focus();
-    }
-  });
-
-  useEffect(() => {
-    setFocusElement(focusStrings[selectedIndex]);
-  }, [selectedIndex]);
-
-  var handleArrowsVerticalScrollDiv = (event) => {
-    if (props.shouldFocus) {
-      if (event.keyCode !== 38) {
-        event.stopPropagation();
-      } else {
-        if (focusables[selectedIndex].scrollTop !== 0) {
-          event.stopPropagation();
-        } else {
-          setSelectedIndex(0);
-        }
-      }
-
-      if (event.keyCode === 39) {
-        setSelectedIndex((selectedIndex + 1) % 3);
-      } else if (event.keyCode === 37 && selectedIndex > 0) {
-        const newIndex = (selectedIndex - 1) % 3;
-        setSelectedIndex(newIndex);
-      }
-    }
-  };
-
-  // <PreviewCarousel
-  //   previews={props.game.gameInfo.previews}
-  //   shouldFocus={false}
-  // ></PreviewCarousel>
 
   const previewContent =
     props.game.gameplayPreviews.length > 0 ? (
       <PreviewCarousel
         previews={props.game.gameplayPreviews}
-        shouldFocus={focusElement === 'previews' && props.shouldFocus}
       ></PreviewCarousel>
     ) : (
       <iframe src={props.game.gameInfo.videoUrl}></iframe>
@@ -128,10 +87,7 @@ const GameDetails = (props) => {
   };
 
   return (
-    <div
-      className="d-flex justify-content-center"
-      onKeyDown={handleArrowsVerticalScrollDiv}
-    >
+    <div className="d-flex justify-content-center">
       <Row className="details-row">
         <Row className="details-title-row">
           <Col>
@@ -139,23 +95,13 @@ const GameDetails = (props) => {
           </Col>
         </Row>
         <Row className="details-detail-row">
-          <Col
-            className="col-3 description-column"
-          >
+          <Col className="col-3 description-column">
             <div>{props.game.gameInfo.description}</div>
           </Col>
-          <Col
-            id="games-preview"
-            className="col-6 game-preview-container"
-            ref={(div) => {
-              focusables.push(div);
-            }}
-          >
+          <Col className="col-6 game-preview-container">
             {previewContent}
           </Col>
-          <Col
-            className="col-3 author-column"
-          >
+          <Col className="col-3 author-column">
             <div>Author Info</div>
           </Col>
         </Row>

--- a/src/components/GameStage/GameDetail/GameDetails.js
+++ b/src/components/GameStage/GameDetail/GameDetails.js
@@ -141,14 +141,11 @@ const GameDetails = (props) => {
         <Row className="details-detail-row">
           <Col
             className="col-3 description-column"
-            tabIndex="-1"
-            ref={(div) => {
-              focusables.push(div);
-            }}
           >
             <div>{props.game.gameInfo.description}</div>
           </Col>
           <Col
+            id="games-preview"
             className="col-6 game-preview-container"
             ref={(div) => {
               focusables.push(div);
@@ -158,10 +155,6 @@ const GameDetails = (props) => {
           </Col>
           <Col
             className="col-3 author-column"
-            tabIndex="-1"
-            ref={(div) => {
-              focusables.push(div);
-            }}
           >
             <div>Author Info</div>
           </Col>

--- a/src/components/GameStage/GameDetail/GamePreview/GamePreview.js
+++ b/src/components/GameStage/GameDetail/GamePreview/GamePreview.js
@@ -10,7 +10,7 @@ export default function GamePreview(props) {
       ? getDriveImageUrl(props.preview.driveId)
       : props.preview.url;
 
-    return <img style={{ width: 'auto', height: '100%' }} src={imageUrl} />;
+    return <img style={{ height: '100%' }} src={imageUrl} />;
   }
 
   function getDriveImageUrl(driveId) {
@@ -18,7 +18,7 @@ export default function GamePreview(props) {
   }
 
   var preview = '';
-  if (props.preview.mediaType.toLowerCase() === 'video') {
+  if (props.preview.type.toLowerCase() === 'video') {
     preview = getVideo();
   } else {
     preview = getImage();

--- a/src/components/GameStage/GameDetail/GamePreview/GamePreview.js
+++ b/src/components/GameStage/GameDetail/GamePreview/GamePreview.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 export default function GamePreview(props) {
+  
   function getVideo() {
     return <iframe src={props.preview.url}></iframe>;
   }
@@ -17,6 +18,10 @@ export default function GamePreview(props) {
     return `https://drive.google.com/uc?export=view&id=${driveId}`;
   }
 
+  // function getYoutubeVideoFrameUrl(driveId) {
+  //   <iframe src={props.game.gameInfo.videoUrl}></iframe>
+  // }
+
   var preview = '';
   if (props.preview.type.toLowerCase() === 'video') {
     preview = getVideo();
@@ -24,9 +29,5 @@ export default function GamePreview(props) {
     preview = getImage();
   }
 
-  const previewId = props.preview.driveId
-    ? props.preview.driveId
-    : props.preview.url;
-
-  return <div id={previewId}>{preview}</div>;
+  return <div ref={(div) => {props.refCallback(div)}} className={props.className}>{preview}</div>;
 }

--- a/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.css
+++ b/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.css
@@ -26,10 +26,6 @@ img {
   margin-bottom: 10px;
   margin-right: 50px;
   border-radius: 10px;
-  transform-origin: center center;
-  transform: scale(1);
-  transition: transform 0.5s;
-  position: sticky;
 
   display: flex;
   justify-content: center;

--- a/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.js
+++ b/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.js
@@ -8,9 +8,8 @@ const PreviewCarousel = (props) => {
   useEffect(() => {
     console.log("Creating interval");
     setInterval(() => {
-      console.log("Changing");
       selectedIndex = (Math.abs(selectedIndex + 1) % props.previews.length);
-      console.log(selectedIndex)
+
       const previewId = props.previews[selectedIndex].driveId
         ? props.previews[selectedIndex].driveId
         : props.previews[selectedIndex].url;
@@ -20,13 +19,13 @@ const PreviewCarousel = (props) => {
         block: 'nearest',
         inline: 'center',
       });
-    }, 3000)
+    }, 8000)
   }, []);
 
   let slider = null;
   let previewCards = props.previews.map((preview, i) => {
     return (
-      <GamePreview isSelected={i === selectedIndex} preview={preview} key={i} />
+      <GamePreview preview={preview} key={i} />
     );
   });
 

--- a/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.js
+++ b/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.js
@@ -3,6 +3,8 @@ import GamePreview from '../GamePreview/GamePreview';
 
 let timer = null
 const PreviewCarousel = (props) => {
+  let slider = null;
+  let carouselElements = [];
   let selectedIndex = 0
 
   useEffect(() => {
@@ -11,24 +13,17 @@ const PreviewCarousel = (props) => {
     
     timer = setInterval(() => {
       selectedIndex = (Math.abs(selectedIndex + 1) % props.previews.length);
-      console.log("Select ", selectedIndex, " - ", props.previews);
-
       const previewId = props.previews[selectedIndex].driveId
         ? props.previews[selectedIndex].driveId
         : props.previews[selectedIndex].url;
-      const selectedCard = document.getElementById(previewId);
 
-      selectedCard.scrollIntoView({
-        block: 'nearest',
-        inline: 'center',
-      });
+      $(slider).animate({scrollLeft: carouselElements[selectedIndex].offsetLeft - $( window ).width()/2 + carouselElements[selectedIndex].scrollWidth}, "slow");
     }, 3000)
   });
 
-  let slider = null;
   let previewCards = props.previews.map((preview, i) => {
     return (
-      <GamePreview preview={preview} key={i} />
+      <GamePreview preview={preview} key={i} refCallback={(div) => carouselElements.push(div)} />
     );
   });
 

--- a/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.js
+++ b/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.js
@@ -1,26 +1,29 @@
 import React, { useEffect, useState } from 'react';
 import GamePreview from '../GamePreview/GamePreview';
-import { propTypes } from 'react-bootstrap/esm/Image';
 
-let selectedIndex = 0
+let timer = null
 const PreviewCarousel = (props) => {
+  let selectedIndex = 0
 
   useEffect(() => {
-    console.log("Creating interval");
-    setInterval(() => {
+    if (timer)
+      clearInterval(timer);
+    
+    timer = setInterval(() => {
       selectedIndex = (Math.abs(selectedIndex + 1) % props.previews.length);
+      console.log("Select ", selectedIndex, " - ", props.previews);
 
       const previewId = props.previews[selectedIndex].driveId
         ? props.previews[selectedIndex].driveId
         : props.previews[selectedIndex].url;
       const selectedCard = document.getElementById(previewId);
-  
+
       selectedCard.scrollIntoView({
         block: 'nearest',
         inline: 'center',
       });
-    }, 8000)
-  }, []);
+    }, 3000)
+  });
 
   let slider = null;
   let previewCards = props.previews.map((preview, i) => {

--- a/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.js
+++ b/src/components/GameStage/GameDetail/PreviewCarousel/PreviewCarousel.js
@@ -2,52 +2,28 @@ import React, { useEffect, useState } from 'react';
 import GamePreview from '../GamePreview/GamePreview';
 import { propTypes } from 'react-bootstrap/esm/Image';
 
+let selectedIndex = 0
 const PreviewCarousel = (props) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
 
   useEffect(() => {
-    if (props.shouldFocus) {
+    console.log("Creating interval");
+    setInterval(() => {
+      console.log("Changing");
+      selectedIndex = (Math.abs(selectedIndex + 1) % props.previews.length);
+      console.log(selectedIndex)
       const previewId = props.previews[selectedIndex].driveId
         ? props.previews[selectedIndex].driveId
         : props.previews[selectedIndex].url;
       const selectedCard = document.getElementById(previewId);
-
+  
       selectedCard.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
+        block: 'nearest',
         inline: 'center',
       });
-    }
-  }, [selectedIndex]);
-
-  useEffect(() => {
-    if (props.shouldFocus) {
-      slider.focus();
-    }
-  });
+    }, 3000)
+  }, []);
 
   let slider = null;
-
-  let handleArrows = (event) => {
-    if (props.shouldFocus) {
-      //left
-      if (event.keyCode === 37 && selectedIndex > 0) {
-        var newIndex =
-          selectedIndex - 1 == -1
-            ? props.previews.length - 1
-            : selectedIndex - 1;
-        setSelectedIndex(newIndex);
-        event.stopPropagation();
-      }
-
-      //right arrow
-      if (event.keyCode === 39 && selectedIndex < previewCards.length - 1) {
-        setSelectedIndex(Math.abs(selectedIndex + 1) % props.previews.length);
-        event.stopPropagation();
-      }
-    }
-  };
-
   let previewCards = props.previews.map((preview, i) => {
     return (
       <GamePreview isSelected={i === selectedIndex} preview={preview} key={i} />
@@ -55,7 +31,7 @@ const PreviewCarousel = (props) => {
   });
 
   return (
-    <div className="slider" onKeyDown={handleArrows}>
+    <div className="slider">
       <div
         className="slides"
         tabIndex="0"

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -4,6 +4,7 @@ import { useObservable } from '../utilities/customHooks.js';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import GameStage from './GameStage/GameStage';
 import './Layout.css';
+window.$ = window.jQuery = require('jquery');
 
 const Layout = (props) => {
   // const games = props.gameService.getGames();


### PR DESCRIPTION
Remove focus from Game details. Focusing on them doesn't add
extra functionality, so it isn't necessary

Change previewCarousel to scroll using the scrollLeft property.
ScrollIntoView includes vertical scrolling on top of horizontal
scrolling and is inconsistent in completing the horizontal scrolling as
a result. This PR changes to pure horizontal scrolling by calculating
and setting the scrollLeft property.

To do this cleanly, we added the use of jquery to get at the properties,
and use refCallbacks to get references to the game previews